### PR TITLE
FIx the bug which will cause the segementaion violation

### DIFF
--- a/invmassfitter/VnVsMassFitter.cxx
+++ b/invmassfitter/VnVsMassFitter.cxx
@@ -609,7 +609,7 @@ Bool_t VnVsMassFitter::MassPrefit() {
   if(fMassBkgFuncType==kPoln) {fMassFitter->SetPolDegreeForBackgroundFit(fPolDegreeBkg);}
   if(fSecondPeak) {fMassFitter->IncludeSecondGausPeak(fSecMass,fFixSecMass,fSecWidth,fFixSecWidth);}
   if(fReflections) {
-    fHistoTemplRfl = (TH1F*)fMassFitter->SetTemplateReflections(fHistoTemplRflInit,fRflOpt,fMinRefl,fMaxRefl);
+    fHistoTemplRfl = (TH1F*)fMassFitter->SetTemplateReflections(fHistoTemplRflInit,fRflOpt,fMinRefl,fMaxRefl)->Clone("fHistoTemplRfl");
     if(fRflOverSig>0) {fMassFitter->SetInitialReflOverS(fRflOverSig);}
     if(fFixRflOverSig) {fMassFitter->SetFixReflOverS(fRflOverSig);}
   }


### PR DESCRIPTION
Hi @stefanopolitano and @Marcellocosti , I see you have already updated the fitter and `get_vn_vs_mass`. Thanks a lot for this. Sorry for the delay, I was stuck on other things.

This PR is only for the problem associated with turning on reflection. So, personally, for D0, I think it's worth having a PR alone.

And I will submit a new PR to implement what I did for the rest part.

Thanks a lot!

PS: by the way, how is the `ttree` in flow task going now? Recently, I saw @Marcellocosti did a lot of work on O2Physics, probably we can add the implementation of ttree now, to converge on a final and stable version for flow task.