### PR TITLE
Dev run analysis: updates on the preparation step

### DIFF
--- a/configs/test_config.yml
+++ b/configs/test_config.yml
@@ -1,13 +1,20 @@
 operations:
-    preprocess_data: false
-    preprocess_mc: false
-    make_yaml: false
-    proj_data: false
-    proj_mc: false
-    efficiencies: true
-    get_vn_vs_mass: false
+    preprocess_data: False
+    preprocess_mc: False
+    make_yaml: False
+    proj_data: False
+    proj_mc: False
+    efficiencies: False
+    get_vn_vs_mass: False
+    ##########################
+    do_syst_frac: False
+    ##########################
+    do_cut_variation: False
+    data_driven_fraction: true
+    get_v2_vs_frac: true
 
 outdir: '/home/mdicosta/alice/hf-vn/test_output'
+outdirPrep: '/home/wuct/ALICE/local/dev/d0_v2' 
 suffix: 'test'
 centrality: 'k3050'
 Dmeson: 'Dplus'
@@ -40,6 +47,24 @@ cut_variation:
             min: [0.06, 0.06, 0.06, 0.06, 0.06, 0.06, 0.06, 0.06, 0.06, 0.06, 0.06, 0.06, 0.04, 0.04]
             max: [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.60, 0.60]
             step: [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
+        skip_cuts: [    # index of the specific cuts to skip for each pt bin
+                [18,19,20,21,22,23,24,25], # pt 1
+                [26], # pt 2
+                [24,25,26], # pt 3
+                [], # pt 4
+                [], # pt 5
+                [], # pt 6
+                [], # pt 7
+                [], # pt 8
+                [], # pt 9
+                [22,23,24,25,26], # pt 10
+                [22,23,24,25,26], # pt 11
+                [22,23,24,25,26], # pt 12
+                [21,22,23,24,25,26], # pt 13
+                [21,22,23,24,25,26], # pt 14
+                [5,9], # pt 15
+            ]
+        syst_frac: [] # 'even', 'random', 'odd', 'minus3low', '1in3', '1in4', 'minus3high', 'minus3' # apply only when filled
     uncorr_bdt_cut:
         bkg_max: # max probability for bkg, one for each pt bin
             - [0.01, 0.02, 0.008, 0.002] # pt 1
@@ -74,7 +99,7 @@ cut_variation:
 
 
 projections:
-    # PtWeightsFile: '/home/mdicosta/alice/hf-vn/ptweights/weights/Dplus/k3050/pTweight_Dplus_k3050_test_Dplus.root'
+    PtWeightsFile: '/home/mdicosta/alice/hf-vn/ptweights/weights/Dplus/k3050/pTweight_Dplus_k3050_test_Dplus.root'
     ApplyPtWeightsD: False
     ApplyPtWeightsB: False
     ApplyBSpeciesWeights: False
@@ -122,20 +147,16 @@ preprocess:
         #     resolution: '/home/mdicosta/alice/hf-vn/datasets/resosp3050l_PASS4_full_PbPb_Reso.root'
     mc: '/home/mdicosta/alice/hf-vn/datasets/MC_Dplus_3050_vsphi_ptsmear20.root'
     axes_data: {
-        "Mass": 2,      # "axis_name": rebin_factor
-        "sp": 1,
-        "score_bkg": 1, 
-        "score_FD": 1
+        axis_names: ['Mass', 'sp', 'score_bkg', 'score_FD'],
+        rebin_factors: [1, 1, 1, 1]
     }
     axes_reco: {
-        "Mass": 1,
-        "Pt": 1,
-        "score_bkg": 1,
-        "score_FD": 1
+        axis_names: ['Mass', 'Pt', 'score_bkg', 'score_FD'],
+        rebin_factors: [1, 1, 1, 1]
     }
     axes_gen: {
-        "Pt": 1,
-        "cent": 1
+        axis_names: ['Pt', 'cent'],
+        rebin_factors: [1, 1]
     }
     workers: 1
     bkg_cuts: [0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2]

--- a/run_analysis.py
+++ b/run_analysis.py
@@ -5,10 +5,10 @@ import yaml
 import concurrent.futures
 import time
 import subprocess
-from concurrent.futures import ProcessPoolExecutor
+# from concurrent.futures import ProcessPoolExecutor
 work_dir = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(f"{work_dir}/utils")
-from utils import check_dir
+from utils import check_dir, logger
 
 paths = {
 	"Preprocess": os.path.join(work_dir, "./src/pre_process.py"),
@@ -16,39 +16,45 @@ paths = {
 	"Projections": os.path.join(work_dir, "./src/proj_thn.py"),
 	"Efficiencies": os.path.join(work_dir, "./src/compute_efficiencies.py"),
 	"GetVnVsMass": os.path.join(work_dir, "./src/get_vn_vs_mass.py"),
+	"CutVariation": os.path.join(work_dir, "./src/cut_variation.py"),
+	"DataDrivenFraction": os.path.join(work_dir, "./src/data_driven_fraction.py"),
+	"GetV2VsFrac": os.path.join(work_dir, "./src/get_v2_vs_frac.py"),
 }
 
-def make_yaml(config, outdir, correlated=False, combined=False):
-	print("\033[32mINFO: Make yaml will be performed\033[0m")
+def make_yaml(flow_config, outdir, correlated=False):
+	logger("YAML file will be created", level="INFO")
 	check_dir(f"{outdir}/cutsets")
-	print(f"\033[32mpython3 {paths['YamlCuts']} {config} -o {outdir} --correlated\033[0m")
-	if correlated:
-		os.system(f"python3 {paths['YamlCuts']} {config} -o {outdir} --correlated")
-	if combined:
-		os.system(f"python3 {paths['YamlCuts']} {config} -o {outdir}")
-
-def project(config, nworkers, mCutSets, correlated=True):
-	print("\033[32mINFO: Projections will be performed\033[0m")
-	check_dir(f"{outdir}/proj")
 
 	method = "--correlated" if correlated else ""
+	cmd = (
+		f'python3 {paths["YamlCuts"]} {flow_config} -o {outdir} {method}'
+	)
 
-	def run_projections(i):
+	logger(f"{cmd}", level="COMMAND")
+	os.system(cmd)
+
+#! I don't see any reason to use bool for correlated and combined here, this is just a flag to decide whether to add a suffix
+def project(flow_config, outdir, nworkers, mCutSets):
+	logger("Projections will be performed", level="INFO")
+	os.makedirs(f"{outdir}/proj", exist_ok=True)
+	logger(f"Output directory for projections: {outdir}/proj", level="INFO")
+
+	def run_projections(i, mCutSets):
 		"""Run sparse projection for a given cutset index."""
 		iCutSets = f"{i:02d}"
 		print(f"\033[32mProcessing cutset {iCutSets}...\033[0m")
 
 		config_cutset = f"{outdir}/cutsets/cutset_{iCutSets}.yml"
 		cmd = (
-			f"python3 {paths['Projections']} {config} -cc {config_cutset} {method}"
+			f"python3 {paths['Projections']} {flow_config} -cc {config_cutset} --mCutSets {mCutSets}"
 		)
 		print(f"\033[32m{cmd}\033[0m")
 		os.system(cmd)
 
 	with concurrent.futures.ThreadPoolExecutor(max_workers=nworkers) as executor:
-		results_proj = list(executor.map(run_projections, range(mCutSets)))
+		results_proj = list(executor.map(run_projections, range(mCutSets), [mCutSets] * mCutSets))
 
-def efficiencies(config, nworkers, mCutSets):
+def efficiencies(flow_config, outdir, nworkers, mCutSets):
 	print("\033[32mINFO: Efficiencies will be computed\033[0m")
 	check_dir(f"{outdir}/eff")
 
@@ -58,8 +64,11 @@ def efficiencies(config, nworkers, mCutSets):
 		print(f"\033[32mProcessing cutset {iCutSet}...\033[0m")
 
 		proj_cutset = f"{outdir}/proj/proj_{iCutSet}.root"
+		if not os.path.exists(proj_cutset):
+			logger(f"Projection file {proj_cutset} does not exist, skipping cutset {iCutSet}", level="ERROR")
+			return
 		cmd = (
-			f"python3 {paths['Efficiencies']} {config} {proj_cutset} -b"
+			f"python3 {paths['Efficiencies']} {flow_config} {proj_cutset} -b"
 		)
 		print(f"\033[32m{cmd}\033[0m")
 		os.system(cmd)
@@ -67,9 +76,9 @@ def efficiencies(config, nworkers, mCutSets):
 	with concurrent.futures.ThreadPoolExecutor(max_workers=nworkers) as executor:
 		results_eff = list(executor.map(run_efficiency, range(mCutSets)))
 
-def get_vn_vs_mass(config, nworkers, mCutSets, batch=False):
+def get_vn_vs_mass(flow_config, outdir, nworkers, mCutSets, batch=False):
 	print("\033[32mINFO: Fit v2 vs mass will be performed\033[0m")
-	check_dir(f"{outdir}/vn")
+	check_dir(f"{outdir}/raw_yields")
 
 	def run_fit(i):
 		"""Run simultaneous fit for a given cutset index."""
@@ -78,9 +87,9 @@ def get_vn_vs_mass(config, nworkers, mCutSets, batch=False):
 
 		proj_cutset = f"{outdir}/proj/proj_{iCutSets}.root"
 		cmd = (
-			f"python3 {paths['GetVnVsMass']} {config} {proj_cutset}"
+			f"python3 {paths['GetVnVsMass']} {flow_config} {proj_cutset}"
 		)
-		if batch: 
+		if batch:
 			cmd += " --batch"
 		print(f"\033[32m{cmd}\033[0m")
 		os.system(cmd)
@@ -88,70 +97,203 @@ def get_vn_vs_mass(config, nworkers, mCutSets, batch=False):
 	with concurrent.futures.ThreadPoolExecutor(max_workers=nworkers) as executor:
 		results_fit = list(executor.map(run_fit, range(mCutSets)))
 
-def run_correlated_cut_variation(config, operations, nworkers, outdir):
+def cut_variaion(flow_config, outdir, correlated, combined=False, operations=None, batch=False):
+	check_dir(f"{outdir}/cutVar")
+	if correlated:
+		logger("Cut variation will be performed", level="INFO")
 
-#___________________________________________________________________________________________________________________________
-	# make yaml file
-	if operations['make_yaml']:
-		make_yaml(config, outdir, correlated=True)
-	else:
-		print("\033[33mWARNING: Make yaml will not be performed\033[0m")
-	
-	mCutSets = len([f for f in os.listdir(f"{outdir}/cutsets") if os.path.isfile(os.path.join(f"{outdir}/cutsets", f))])
-	print(f"mCutSets: {mCutSets}")
-#___________________________________________________________________________________________________________________________
-	# Projection for MC and apply the ptweights
-	if operations["proj_mc"] or operations["proj_data"]:
-		project(config, nworkers, mCutSets)
-	else:
-		print("\033[33mWARNING: Projections will not be performed\033[0m")
+		ry_path = f"{outdir}/raw_yields"
+		eff_path = f"{outdir}/eff"
+		method = "--correlated" if correlated else ""
 
-#___________________________________________________________________________________________________________________________
-	# Efficiencies
-	if operations["efficiencies"]:
-		efficiencies(config, nworkers, mCutSets)
-	else:
-		print("\033[33mWARNING: Efficiencies will not be computed\033[0m")
+		cmd = (
+			f"python3 {paths['CutVariation']} {flow_config} {ry_path} {eff_path} {method}"
+		)
+		if batch:
+			cmd += " --batch"
+		logger(f"{cmd}", level="COMMAND")
+		os.system(cmd)
 
-#___________________________________________________________________________________________________________________________
-	# Simultaneous fit
-	if operations["get_vn_vs_mass"]:
-		get_vn_vs_mass(config, nworkers, mCutSets, True)
-	else:
-		print("\033[33mWARNING: Fit v2 vs mass will not be performed\033[0m")
+	if combined:
+		outdirCorr = os.path.join(os.path.dirname(outdir), os.path.basename(outdir).replace("_combined", "_correlated"))
+		if os.path.exists(f"{outdirCorr}/cutVar/cutVar.root"):
+			logger("Cut variation with correlated cuts found!", level="INFO")
+			cmd = (
+				f"cp {outdirCorr}/cutVar/cutVar.root {outdir}/cutVar/cutVar.root"
+			)
+			logger(f"{cmd}", level="COMMAND")
+			os.system(cmd)
+		else:
+			logger(f"Cut variation with correlated cuts not found in {outdirCorr}, running correlated cut variation", level="WARNING")
 
-def run_combined_cut_variation(config, operations, nworkers, outdir):
+			logger("Running analysis with correlated cut variation", level="WARNING")
+			logger("========================================================================================", level="WARNING")
+			import copy
+			operationsCorr = copy.deepcopy(operations)
+			for key in operationsCorr:
+				if key in ['do_cut_variation', 'make_yaml', 'proj_mc', 'proj_data', 'efficiencies', 'get_vn_vs_mass']:
+					operationsCorr[key] = True
+				else:
+					operationsCorr[key] = False
+			os.makedirs(os.path.join(outdir, "config_flow"), exist_ok=True)
+			flow_configCorr = os.path.join(outdir, "config_flow", f"corr_{os.path.basename(flow_config)}")
+			with open(flow_config, 'r') as cfgFlow:
+				config = yaml.safe_load(cfgFlow)
+				config['operations'] = operationsCorr
+				config['outdir'] = outdirCorr #! make sure all output directories are set from function arguments not from config file
+				with open(flow_configCorr, 'w') as cfgFlow:
+					yaml.dump(config, cfgFlow, default_flow_style=True)
+			logger(f"Using temporary flow config: {flow_configCorr}", level="WARNING")
+			run_correlated_cut_variation(flow_configCorr, operationsCorr, nworkers, outdirCorr)
+			logger("========================================================================================", level="WARNING")
+
+			logger("Copying cut variation with correlated cuts to combined cut variation", level="WARNING")
+			cmd = (
+				f"cp {outdirCorr}/cutVar/cutVar.root {outdir}/cutVar/cutVar.root"
+			)
+			logger(f"{cmd}", level="COMMAND")
+			os.system(cmd)
+
+def data_driven_fraction(outdir, syst_frac, batch=False):
+	logger("Data driven fraction will be performed", level="INFO")
+	check_dir(f"{outdir}/frac")
+ 
+	cutvar_file = f"{outdir}/cutVar/cutVar.root"
+	eff_path = f"{outdir}/eff"
+
+	cmd = (
+		f"python3 {paths['DataDrivenFraction']} {cutvar_file} {eff_path}"
+	)
+	if syst_frac:
+		cmd += " --syst_frac"
+	if batch:
+		cmd += " --batch"
+	logger(f"{cmd}", level="COMMAND")
+	os.system(cmd)
+ 
+def get_v2_vs_frac(flow_config, outdir, correlated=False, batch=False):
+	logger("Fit v2 vs fd fraction will be performed", level="INFO")
+	check_dir(f"{outdir}/v2")
+
+	ry_path = f"{outdir}/raw_yields"
+	frac_path = f"{outdir}/frac"
+	cmd = (
+		f"python3 {paths['GetV2VsFrac']} {flow_config} {ry_path} {frac_path}"
+	)
+	if correlated:
+		cmd += " --correlated"
+	if batch:
+		cmd += " --batch"
+	logger(f"{cmd}", level="COMMAND")
+	os.system(cmd)
+
+def run_correlated_cut_variation(flow_config, operations, nworkers, outdir):
 
 	#___________________________________________________________________________________________________________________________
 	# make yaml file
-	if operations['make_yaml']:
-		make_yaml(config, outdir, combined=True)
+	if operations.get('make_yaml', False):
+		make_yaml(flow_config, outdir, correlated=True)
 	else:
 		print("\033[33mWARNING: Make yaml will not be performed\033[0m")
 
 	mCutSets = len([f for f in os.listdir(f"{outdir}/cutsets") if os.path.isfile(os.path.join(f"{outdir}/cutsets", f))])
 	print(f"mCutSets: {mCutSets}")
 
-#___________________________________________________________________________________________________________________________
+	#___________________________________________________________________________________________________________________________
 	# Projection for MC and apply the ptweights
-	if operations["proj_mc"] or operations["proj_data"]:
-		project(config, nworkers, mCutSets, correlated=False)
+	if operations.get('proj_mc', False) or operations.get('proj_data', False):
+		project(flow_config, outdir, nworkers, mCutSets)
 	else:
 		print("\033[33mWARNING: Projections will not be performed\033[0m")
 
-#___________________________________________________________________________________________________________________________
+	#___________________________________________________________________________________________________________________________
 	# Efficiencies
-	if operations["efficiencies"]:
-		efficiencies(config, nworkers, mCutSets)
+	if operations.get('efficiencies', False):
+		efficiencies(flow_config, outdir, nworkers, mCutSets)
 	else:
 		print("\033[33mWARNING: Efficiencies will not be computed\033[0m")
 
-#___________________________________________________________________________________________________________________________
+	#___________________________________________________________________________________________________________________________
 	# Simultaneous fit
-	if operations["get_vn_vs_mass"]:
-		get_vn_vs_mass(config, nworkers, mCutSets, True)
+	if operations.get('get_vn_vs_mass', False):
+		get_vn_vs_mass(flow_config, outdir, nworkers, mCutSets, True)
 	else:
 		print("\033[33mWARNING: Fit v2 vs mass will not be performed\033[0m")
+
+	#___________________________________________________________________________________________________________________________
+	# Cut variation
+	if operations.get('do_cut_variation'):
+		cut_variaion(flow_config, outdir, correlated=True, combined=False, operations=operations, batch=True)
+	else:
+		logger("Cut variation will not be performed", level="WARNING")
+  
+	#___________________________________________________________________________________________________________________________
+ 	# Data driven fraction
+	if operations.get('data_driven_fraction', False):
+		data_driven_fraction(outdir, syst_frac=False, batch=True)
+	else:
+		logger("Data driven fraction will not be performed", level="WARNING")
+
+	#___________________________________________________________________________________________________________________________
+ 	# linear fit of vn vs fd fraction
+	if operations.get('get_v2_vs_frac'):
+		get_v2_vs_frac(flow_config, outdir, correlated=True, batch=True)
+	else:
+		logger("Fit v2 vs fd fraction will not be performed", level="WARNING")
+
+def run_combined_cut_variation(flow_config, operations, nworkers, outdir):
+
+	#___________________________________________________________________________________________________________________________
+	# make yaml file
+	if operations.get('make_yaml', False):
+		make_yaml(flow_config, outdir, correlated=False)
+	else:
+		print("\033[33mWARNING: Make yaml will not be performed\033[0m")
+
+	mCutSets = len([f for f in os.listdir(f"{outdir}/cutsets") if os.path.isfile(os.path.join(f"{outdir}/cutsets", f))])
+	print(f"mCutSets: {mCutSets}")
+
+	#___________________________________________________________________________________________________________________________
+	# Projection for MC and apply the ptweights
+	if operations.get('proj_mc', False) or operations.get('proj_data', False):
+		project(flow_config, outdir, nworkers, mCutSets)
+	else:
+		print("\033[33mWARNING: Projections will not be performed\033[0m")
+
+	#___________________________________________________________________________________________________________________________
+	# Efficiencies
+	if operations.get('efficiencies', False):
+		efficiencies(flow_config, outdir, nworkers, mCutSets)
+	else:
+		print("\033[33mWARNING: Efficiencies will not be computed\033[0m")
+
+	#___________________________________________________________________________________________________________________________
+	# Simultaneous fit
+	if operations.get('get_vn_vs_mass', False):
+		get_vn_vs_mass(flow_config, outdir, nworkers, mCutSets, True)
+	else:
+		print("\033[33mWARNING: Fit v2 vs mass will not be performed\033[0m")
+
+	#___________________________________________________________________________________________________________________________
+	# Cut variation
+	if operations.get('do_cut_variation', False):
+		cut_variaion(flow_config, outdir, correlated=False, combined=True, operations=operations, batch=True)
+	else:
+		logger("Cut variation will not be performed", level="WARNING")
+  
+	#___________________________________________________________________________________________________________________________
+	# Data driven fraction
+	if operations.get('data_driven_fraction', False):
+		data_driven_fraction(outdir, syst_frac=True, batch=True)
+	else:
+		logger("Data driven fraction will not be performed", level="WARNING")
+  
+	#___________________________________________________________________________________________________________________________
+	# linear fit of vn vs fd fraction
+	if operations.get('get_v2_vs_frac'):
+		get_v2_vs_frac(flow_config, outdir, correlated=False, batch=True)
+	else:
+		logger("Fit v2 vs fd fraction will not be performed", level="WARNING")
 
 if __name__ == "__main__":
 	parser = argparse.ArgumentParser(description='Arguments')
@@ -165,7 +307,7 @@ if __name__ == "__main__":
 	# Load and copy the configuration file
 	with open(args.flow_config, 'r') as cfgFlow:
 		config = yaml.safe_load(cfgFlow)
- 
+
 	operations = config['operations']
 	nworkers = config['nworkers']
 	if args.correlated:
@@ -173,13 +315,13 @@ if __name__ == "__main__":
 	else:
 		outdir = f"{config['outdir']}/cutvar_{config['suffix']}" + "_combined"
 	os.system(f"mkdir -p {outdir}")
-  
+
 	# copy the configuration file
 	nfile = 0
 	os.makedirs(f'{outdir}/config_flow', exist_ok=True)
-	while os.path.exists(f'{outdir}/config_flow/{os.path.splitext(os.path.basename(args.flow_config))[0]}_{config['suffix']}_{nfile}.yml'):
+	while os.path.exists(f'{outdir}/config_flow/{os.path.splitext(os.path.basename(args.flow_config))[0]}_{config["suffix"]}_{nfile}.yml'):
 		nfile = nfile + 1
-	os.system(f'cp {args.flow_config} {outdir}/config_flow/{os.path.splitext(os.path.basename(args.flow_config))[0]}_{config['suffix']}_{nfile}.yml')
+	os.system(f'cp {args.flow_config} {outdir}/config_flow/{os.path.splitext(os.path.basename(args.flow_config))[0]}_{config["suffix"]}_{nfile}.yml')
 
 	if operations.get('preprocess_data') or operations.get('preprocess_mc'):
 		print("\033[32mINFO: Preprocess will be performed\033[0m")
@@ -194,7 +336,7 @@ if __name__ == "__main__":
 		run_correlated_cut_variation(args.flow_config, operations, nworkers, outdir)
 	if args.combined:
 		run_combined_cut_variation(args.flow_config, operations, nworkers, outdir)
-  
+
 	end_time = time.time()
 	execution_time = end_time - start_time
 	print(f"\033[34mTotal execution time: {execution_time:.2f} seconds\033[0m")

--- a/src/make_cutsets_cfgs.py
+++ b/src/make_cutsets_cfgs.py
@@ -58,9 +58,9 @@ def make_yaml(flow_config, outputdir, correlated):
     sig_cuts_upper = list(map(list, zip(*sig_cuts_upper)))
 
     if correlated:
-        bkg_cuts_upper = [cfg_cutvar['corr_bdt_cut']['bkg_max']] * maxCutSets
+        bkg_cuts_upper = [[cut for iCut, cut in enumerate(cfg_cutvar['corr_bdt_cut']['bkg_max']) if iCut < nPtBins]] * maxCutSets
     else:
-        bkg_cuts_upper = [pad_to_length(cuts, maxCutSets) for cuts in cfg_cutvar['uncorr_bdt_cut']['bkg_max']]
+        bkg_cuts_upper = [pad_to_length(cuts, maxCutSets) for iCut, cuts in enumerate(cfg_cutvar['uncorr_bdt_cut']['bkg_max']) if iCut < nPtBins]
         bkg_cuts_upper  = list(map(list, zip(*bkg_cuts_upper)))
 
     os.makedirs(f'{outputdir}/cutsets', exist_ok=True)

--- a/utils/sparse_dicts.py
+++ b/utils/sparse_dicts.py
@@ -35,8 +35,12 @@ def get_sparses_dicts(config):
             'occ': 11,
         }
         axes_dict['RecoFD'] = axes_dict['RecoPrompt']
+        axes_dict['RecoRefl'] = axes_dict['RecoPrompt']
+        axes_dict['RecoReflPrompt'] = axes_dict['RecoPrompt']
+        axes_dict['RecoReflFD'] = axes_dict['RecoPrompt']
         axes_dict['GenPrompt'] = {
             'Pt': 0,
+            'pt_bmoth': 1,
             'y': 2,
             'origin': 3,
             'npvcontr': 4,
@@ -132,12 +136,12 @@ def get_pt_preprocessed_sparses(config, iPt):
     logger("Loading preprocessed sparses", level='INFO')
     sparsesFlow, sparsesReco, sparsesGen, axes_dict, resolutions = {}, {}, {}, {}, {}
     pre_cfg = config['preprocess']
-    axes_dict['Flow'] = {ax: iax for iax, (ax, _) in enumerate(pre_cfg['axes_data'].items())}
+    axes_dict['Flow'] = {ax: iax for iax, ax in enumerate(pre_cfg['axes_data']['axis_names'])}
     ptmin = config["ptbins"][iPt]
     ptmax = config["ptbins"][iPt+1]
 
-    if config.get("outdirprep"):
-        infileprep = TFile(f"{config['outdirprep']}/preprocess/AnalysisResults_pt_{int(ptmin*10)}_{int(ptmax*10)}.root")
+    if config.get("outdirPrep") and config["outdirPrep"] != "":
+        infileprep = TFile(f"{config['outdirPrep']}/preprocess/AnalysisResults_pt_{int(ptmin*10)}_{int(ptmax*10)}.root")
     else:
         infileprep = TFile(f"{config['outdir']}/preprocess/AnalysisResults_pt_{int(ptmin*10)}_{int(ptmax*10)}.root")
 
@@ -151,13 +155,13 @@ def get_pt_preprocessed_sparses(config, iPt):
         for key in subdir.GetListOfKeys():
             obj = key.ReadObj()
             sparsesReco[key.GetName()[1:]] = obj
-            axes_dict[key.GetName()[1:]] = {ax: iax for iax, (ax, _) in enumerate(pre_cfg['axes_reco'].items())}
+            axes_dict[key.GetName()[1:]] = {ax: iax for iax, ax in enumerate(pre_cfg['axes_reco']['axis_names'])}
 
         subdir = infileprep.Get("MC/Gen")
         for key in subdir.GetListOfKeys():
             obj = key.ReadObj()
             sparsesGen[key.GetName()[1:]] = obj
-            axes_dict[key.GetName()[1:]] = {ax: iax for iax, (ax, _) in enumerate(pre_cfg['axes_gen'].items())}
+            axes_dict[key.GetName()[1:]] = {ax: iax for iax, ax in enumerate(pre_cfg['axes_gen']['axis_names'])}
 
     infileprep.Close()
 
@@ -226,31 +230,37 @@ def get_sparses(config, get_data=True, get_mc=True, debug=False):
         if config['Dmeson'] == 'Dzero':
             sparseD0Path = 'hf-task-d0/hBdtScoreVsMassVsPtVsPtBVsYVsOriginVsD0Type'
             sparsesReco['RecoPrompt'] = [file.Get(sparseD0Path) for file in infiletask]
-            sparsesReco['RecoPrompt'].GetAxis(axes_dict['RecoPrompt']['origin']).SetRange(2, 2)    # make sure it is prompt
-            sparsesReco['RecoPrompt'].GetAxis(axes_dict['RecoPrompt']['cand_type']).SetRange(1, 2) # make sure it is signal
+            for ifile in range(len(sparsesReco['RecoPrompt'])):
+                sparsesReco['RecoPrompt'][ifile].GetAxis(axes_dict['RecoPrompt']['origin']).SetRange(2, 2)    # make sure it is prompt
+                sparsesReco['RecoPrompt'][ifile].GetAxis(axes_dict['RecoPrompt']['cand_type']).SetRange(1, 2) # make sure it is signal
 
             sparsesReco['RecoFD'] = [file.Get(sparseD0Path) for file in infiletask]
-            sparsesReco['RecoFD'].GetAxis(axes_dict['RecoFD']['origin']).SetRange(3, 3)       # make sure it is non-prompt
-            sparsesReco['RecoFD'].GetAxis(axes_dict['RecoFD']['cand_type']).SetRange(1, 2)    # make sure it is signal
+            for ifile in range(len(sparsesReco['RecoFD'])):
+                sparsesReco['RecoFD'][ifile].GetAxis(axes_dict['RecoPrompt']['origin']).SetRange(3, 3)       # make sure it is non-prompt
+                sparsesReco['RecoFD'][ifile].GetAxis(axes_dict['RecoPrompt']['cand_type']).SetRange(1, 2)    # make sure it is signal
 
             sparsesReco['RecoRefl'] = [file.Get(sparseD0Path) for file in infiletask]
-            sparsesReco['RecoRefl'].GetAxis(axes_dict['RecoRefl']['cand_type']).SetRange(3, 4)  # make sure it is reflection
+            for ifile in range(len(sparsesReco['RecoRefl'])):
+                sparsesReco['RecoRefl'][ifile].GetAxis(axes_dict['RecoPrompt']['cand_type']).SetRange(3, 4)  # make sure it is reflection
 
             sparsesReco['RecoReflPrompt'] = [file.Get(sparseD0Path) for file in infiletask]
-            sparsesReco['RecoReflPrompt'].GetAxis(axes_dict['RecoReflPrompt']['cand_type']).SetRange(3, 4)    # make sure it is reflection
-            sparsesReco['RecoReflPrompt'].GetAxis(axes_dict['RecoReflPrompt']['origin']).SetRange(2, 2)       # make sure it is prompt
+            for ifile in range(len(sparsesReco['RecoReflPrompt'])):
+                sparsesReco['RecoReflPrompt'][ifile].GetAxis(axes_dict['RecoPrompt']['cand_type']).SetRange(3, 4)  # make sure it is reflection
+                sparsesReco['RecoReflPrompt'][ifile].GetAxis(axes_dict['RecoPrompt']['origin']).SetRange(2, 2)       # make sure it is prompt   
 
             sparsesReco['RecoReflFD'] = [file.Get(sparseD0Path) for file in infiletask]
-            sparsesReco['RecoReflFD'].GetAxis(axes_dict['RecoReflFD']['cand_type']).SetRange(3, 4)    # make sure it is reflection
-            sparsesReco['RecoReflFD'].GetAxis(axes_dict['RecoReflFD']['origin']).SetRange(3, 3)       # make sure it is FD
+            for ifile in range(len(sparsesReco['RecoReflFD'])):
+                sparsesReco['RecoReflFD'][ifile].GetAxis(axes_dict['RecoPrompt']['cand_type']).SetRange(3, 4)    # make sure it is reflection
+                sparsesReco['RecoReflFD'][ifile].GetAxis(axes_dict['RecoPrompt']['origin']).SetRange(3, 3)       # make sure it is FD
             #TODO: safety checks for Dmeson reflecton and secondary peak
 
             sparsesGen['GenPrompt'] = [file.Get('hf-task-d0/hSparseAcc') for file in infiletask]
-            sparsesGen['GenPrompt'].GetAxis(axes_dict['GenPrompt']['origin']).SetRange(2, 2)  # make sure it is prompt
+            for ifile in range(len(sparsesGen['GenPrompt'])):
+                sparsesGen['GenPrompt'][ifile].GetAxis(axes_dict['GenPrompt']['origin']).SetRange(2, 2)  # make sure it is prompt
 
             sparsesGen['GenFD'] = [file.Get('hf-task-d0/hSparseAcc') for file in infiletask]
-            sparsesGen['GenFD'].GetAxis(axes_dict['GenFD']['origin']).SetRange(3, 3)  # make sure it is non-prompt
-            #TODO: safety checks for Dmeson reflecton and secondary peak
+            for ifile in range(len(sparsesGen['GenFD'])):
+                sparsesGen['GenFD'][ifile].GetAxis(axes_dict['GenFD']['origin']).SetRange(3, 3)  # make sure it is non-prompt
         elif config['Dmeson'] == 'Dplus':
             sparsesReco['RecoFD']     = [file.Get('hf-task-dplus/hSparseMassFD') for file in infiletask]
             sparsesReco['RecoPrompt'] = [file.Get('hf-task-dplus/hSparseMassPrompt') for file in infiletask]


### PR DESCRIPTION
Hi @stefanopolitano and @Marcellocosti, sorry for the late PR; I had to stop for a while due to some details.

This is the first PR, focusing on the preparation step. Details as listed below:

- run_analysis.py
-- add cut variation, fraction by data-driven method, and v2 vs fraction
-- all output directory in run_analysis comes from `outdir`. And from projection to sim fit, basically there is no difference between corr. and combine, then the rest is controlled by the flag `correlated`.
-- the logic of `run_combined_cut_variation`, find the correlated one in the same parent directory, otherwise run the `run_correlated_cut_variation` to produce the cut variation with correlated cutsets and copy it to the directory of the combined one.

- config_flow yml file:
-- all operations
-- since the main workflow always loads the pre-processed `AnalysisReuslts.root`, so it's necessary to specify a `outdirPrep` to load the input from a directory which is different from the `outdir`. It's more like `inputDir`.
-- using a list for the `axis_XXX`, since the order of the names is very important for the pre-procese, the axes in thnsparse is decided by this order. If using dict, the order will be changed when restoring the yml file. (I see there has been a systematic script, please check whether the order in muiltrail config file changed)

- src/make_cutsets_cfgs.py and src/pre_process.py:
-- change the way to load the `axis_dict` accordingly
-- using the `rebin_gen` for thnsparse of generation
-- updates for D0 case