### PR TITLE
fix some minor bugs for D0 case and update

### DIFF
--- a/run_analysis.py
+++ b/run_analysis.py
@@ -319,14 +319,13 @@ if __name__ == "__main__":
 	os.system(f'cp {args.flow_config} {outdir}/config_flow/{os.path.splitext(os.path.basename(args.flow_config))[0]}_{config["suffix"]}_{nfile}.yml')
 
 	if operations.get('preprocess'):
-		print("\033[32mINFO: Preprocess will be performed\033[0m")
+		logger("Preprocess will be performed", level="INFO")
 		os.system(f"python3 {paths['Preprocess']} {args.flow_config} --workers {nworkers}")
 	else:
-		print("\033[33mWARNING: Preprocess will not be performed\033[0m")
+		logger("Preprocess will not be performed", level="WARNING")
 
 	if not args.correlated and not args.combined:
-		print("\033[33mWARNING: No cut variation will be performed\033[0m")
-		sys.exit(0)
+		logger("No cut variation will be performed, please specify --correlated or --combined", level="ERROR")
 	if args.correlated:
 		run_correlated_cut_variation(args.flow_config, operations, nworkers, outdir)
 	if args.combined:
@@ -334,4 +333,4 @@ if __name__ == "__main__":
 
 	end_time = time.time()
 	execution_time = end_time - start_time
-	print(f"\033[34mTotal execution time: {execution_time:.2f} seconds\033[0m")
+	logger("Analysis completed, total execution time: {:.2f} seconds".format(execution_time), level="INFO")

--- a/run_analysis.py
+++ b/run_analysis.py
@@ -325,7 +325,8 @@ if __name__ == "__main__":
 		logger("Preprocess will not be performed", level="WARNING")
 
 	if not args.correlated and not args.combined:
-		logger("No cut variation will be performed, please specify --correlated or --combined", level="ERROR")
+		logger("No cut variation will be performed, please specify --correlated or --combined", level="WARNING")
+		sys.exit(0)
 	if args.correlated:
 		run_correlated_cut_variation(args.flow_config, operations, nworkers, outdir)
 	if args.combined:

--- a/src/cut_variation.py
+++ b/src/cut_variation.py
@@ -38,7 +38,7 @@ def minimise_chi2(config, ptmins, ptmaxs, hRawYields, hEffPrompt, hEffFD, inputP
     hCovCorrYields = [[hRawYields[0].Clone('hCovPromptPrompt'), hRawYields[0].Clone('hCovPromptFD')],
                       [hRawYields[0].Clone('hCovFDPrompt'), hRawYields[0].Clone('hCovFDFD')]]
 
-    suggestted_skipped_cuts_pts = suggest_skip_cuts(hRawYields, hEffPrompt, hEffFD, len(ptmins))
+    suggested_skipped_cuts_pts = suggest_skip_cuts(hRawYields, hEffPrompt, hEffFD, len(ptmins))
     skip_cuts_pts = config.get('minimisation', {}).get('skip_cuts', [])
 
     for iRow, row in enumerate(hCovCorrYields):

--- a/src/cut_variation.py
+++ b/src/cut_variation.py
@@ -12,7 +12,7 @@ from ROOT import kBlack, kRed, kAzure, kGreen, kRainBow # pylint: disable=import
 from ROOT import kFullCircle, kFullSquare, kOpenSquare, kOpenCircle # pylint: disable=import-error,no-name-in-module
 script_dir = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(script_dir, '..', 'utils'))
-from utils import logger
+from utils import logger, suggest_skip_cuts
 from frac_utils import GetMinimisation
 from load_utils import load_root_files
 from StyleFormatter import SetGlobalStyle, SetObjectStyle
@@ -38,6 +38,9 @@ def minimise_chi2(config, ptmins, ptmaxs, hRawYields, hEffPrompt, hEffFD, inputP
     hCovCorrYields = [[hRawYields[0].Clone('hCovPromptPrompt'), hRawYields[0].Clone('hCovPromptFD')],
                       [hRawYields[0].Clone('hCovFDPrompt'), hRawYields[0].Clone('hCovFDFD')]]
 
+    suggestted_skipped_cuts_pts = suggest_skip_cuts(hRawYields, hEffPrompt, hEffFD, len(ptmins))
+    skip_cuts_pts = config.get('minimisation', {}).get('skip_cuts', [])
+
     for iRow, row in enumerate(hCovCorrYields):
         for iCol, hCov in enumerate(row):
             SetObjectStyle(hCov, linecolor=kBlack)
@@ -58,15 +61,20 @@ def minimise_chi2(config, ptmins, ptmaxs, hRawYields, hEffPrompt, hEffFD, inputP
                     last_FD_score_cut = cutsetConfig['ScoreFD']['min'][iPt]
                 else:
                     if last_FD_score_cut == cutsetConfig['ScoreFD']['min'][iPt]:
-                        logger(f'Cut set {iCut} has the same FD score cut as the previous one for pt {ptMin:.1f}-{ptMax:.1f}, skipping it.', level='WARNING')
+                        logger(f'Skipping the duplicate cut set {iCut} for pt {ptMin:.1f}-{ptMax:.1f}', level='WARNING')
                         continue
                     last_FD_score_cut = cutsetConfig['ScoreFD']['min'][iPt]
 
+            # also skip cuts as suggested by the check
+            if iCut in suggestted_skipped_cuts_pts[iPt]:
+                logger(f'Skipping cut set {iCut} for pt {ptMin:.1f}-{ptMax:.1f} as suggested by check', level='WARNING')
+                continue
+
             # if skip_cuts is defined check if the cut number is present for that pt
-            if config.get('minimisation') and config['minimisation'].get('skip_cuts'):
-                if iCut in config['minimisation']['skip_cuts'][iPt]:
-                    logger(f'Skipping cut set {iCut} for pt {ptMin:.1f}-{ptMax:.1f}', level='WARNING')
-                    continue
+            if iPt < len(skip_cuts_pts) and iCut in skip_cuts_pts[iPt]:
+                logger(f'Skipping cut set {iCut} for pt {ptMin:.1f}-{ptMax:.1f}', level='WARNING')
+                continue
+
             listRawYield.append(hRaw.GetBinContent(iPt+1))
             listRawYieldUnc.append(hRaw.GetBinError(iPt+1))
             listEffPrompt.append(hEffP.GetBinContent(iPt+1))

--- a/src/cut_variation.py
+++ b/src/cut_variation.py
@@ -66,7 +66,7 @@ def minimise_chi2(config, ptmins, ptmaxs, hRawYields, hEffPrompt, hEffFD, inputP
                     last_FD_score_cut = cutsetConfig['ScoreFD']['min'][iPt]
 
             # also skip cuts as suggested by the check
-            if iCut in suggestted_skipped_cuts_pts[iPt]:
+            if iCut in suggested_skipped_cuts_pts[iPt]:
                 logger(f'Skipping cut set {iCut} for pt {ptMin:.1f}-{ptMax:.1f} as suggested by check', level='WARNING')
                 continue
 

--- a/src/get_vn_vs_mass.py
+++ b/src/get_vn_vs_mass.py
@@ -18,8 +18,8 @@ from ROOT import gSystem
 if not hasattr(gSystem, "_vnfitter_loaded"):
     script_dir = os.path.dirname(os.path.realpath(__file__))
     # gSystem.Load(f"{script_dir}/../invmassfitter/libvnfitter.so")
-    gSystem.CompileMacro(f"{script_dir}/../invmassfitter/VnVsMassFitter.cxx", "kO", "")
-    gSystem.CompileMacro(f"{script_dir}/../invmassfitter/InvMassFitter.cxx", "kO", "")
+    gSystem.CompileMacro(f"{script_dir}/../invmassfitter/VnVsMassFitter.cxx", "kO")
+    gSystem.CompileMacro(f"{script_dir}/../invmassfitter/InvMassFitter.cxx", "kO")
     gSystem.Load(f"{script_dir}/../invmassfitter/VnVsMassFitter_cxx.so")
     gSystem.Load(f"{script_dir}/../invmassfitter/InvMassFitter_cxx.so")
     gSystem._vnfitter_loaded = True

--- a/src/get_vn_vs_mass.py
+++ b/src/get_vn_vs_mass.py
@@ -20,8 +20,6 @@ if not hasattr(gSystem, "_vnfitter_loaded"):
     # gSystem.Load(f"{script_dir}/../invmassfitter/libvnfitter.so")
     gSystem.CompileMacro(f"{script_dir}/../invmassfitter/VnVsMassFitter.cxx", "kO")
     gSystem.CompileMacro(f"{script_dir}/../invmassfitter/InvMassFitter.cxx", "kO")
-    gSystem.Load(f"{script_dir}/../invmassfitter/VnVsMassFitter_cxx.so")
-    gSystem.Load(f"{script_dir}/../invmassfitter/InvMassFitter_cxx.so")
     gSystem._vnfitter_loaded = True
 from ROOT import InvMassFitter, VnVsMassFitter
 os.sys.path.append(os.path.join(script_dir, '..', 'utils'))

--- a/src/get_vn_vs_mass.py
+++ b/src/get_vn_vs_mass.py
@@ -17,7 +17,11 @@ ROOT.gErrorIgnoreLevel = ROOT.kError  # Only show errors and above
 from ROOT import gSystem
 if not hasattr(gSystem, "_vnfitter_loaded"):
     script_dir = os.path.dirname(os.path.realpath(__file__))
-    gSystem.Load(f"{script_dir}/../invmassfitter/libvnfitter.so")
+    # gSystem.Load(f"{script_dir}/../invmassfitter/libvnfitter.so")
+    gSystem.CompileMacro(f"{script_dir}/../invmassfitter/VnVsMassFitter.cxx", "kO", "")
+    gSystem.CompileMacro(f"{script_dir}/../invmassfitter/InvMassFitter.cxx", "kO", "")
+    gSystem.Load(f"{script_dir}/../invmassfitter/VnVsMassFitter_cxx.so")
+    gSystem.Load(f"{script_dir}/../invmassfitter/InvMassFitter_cxx.so")
     gSystem._vnfitter_loaded = True
 from ROOT import InvMassFitter, VnVsMassFitter
 os.sys.path.append(os.path.join(script_dir, '..', 'utils'))

--- a/src/pre_process.py
+++ b/src/pre_process.py
@@ -63,7 +63,7 @@ def get_inputs_sparse(file, full_cfg, sparse_cfg, debug=False):
     else:
         logger(f"Sparse {sparse} loaded from {sparse_cfg['path']}", level='INFO')
     
-    if full_cfg['Dmeson'] == 'Dzero':
+    if full_cfg['Dmeson'] == 'Dzero' and sparse_cfg['name'] != "FlowSP":
         # TODO: safety checks for Dmeson reflecton and secondary peak
         if sparse_cfg['name'] == "RecoPrompt":
             sparse.GetAxis(axes['Origin']).SetRange(2, 2)       # select prompt
@@ -75,14 +75,14 @@ def get_inputs_sparse(file, full_cfg, sparse_cfg, debug=False):
             sparse.GetAxis(axes['CandType']).SetRange(3, 4)     # select reflection
         elif sparse_cfg['name'] == "RecoReflPrompt":
             sparse.GetAxis(axes['CandType']).SetRange(3, 4)     # select reflection
-            sparse.GetAxis(axes['Origin']).SetRange(2, 2)       # select prompt
+            sparse.GetAxis(axes['Origin']).SetRange(2, 2)       # select prompt   
         elif sparse_cfg['name'] == "RecoReflFD":
             sparse.GetAxis(axes['CandType']).SetRange(3, 4)     # select reflection
             sparse.GetAxis(axes['Origin']).SetRange(3, 3)       # select FD
         elif sparse_cfg['name'] == "GenPrompt":
-            sparsesGen['GenPrompt'][i_file].GetAxis(axes_dict['GenPrompt']['Origin']).SetRange(2, 2)  # select prompt
+            sparse.GetAxis(axes['Origin']).SetRange(2, 2)       # select prompt
         elif sparse_cfg['name'] == "GenFD":
-            sparsesGen['GenFD'][i_file].GetAxis(axes_dict['GenFD']['Origin']).SetRange(3, 3)  # select non-prompt
+            sparse.GetAxis(axes['Origin']).SetRange(3, 3)       # select non-prompt
         else:
             logger(f"Unknown sparse type for Dzero {sparse_cfg['name']}", level='ERROR')
 

--- a/src/pre_process.py
+++ b/src/pre_process.py
@@ -75,7 +75,7 @@ def get_inputs_sparse(file, full_cfg, sparse_cfg, debug=False):
             sparse.GetAxis(axes['CandType']).SetRange(3, 4)     # select reflection
         elif sparse_cfg['name'] == "RecoReflPrompt":
             sparse.GetAxis(axes['CandType']).SetRange(3, 4)     # select reflection
-            sparse.GetAxis(axes['Origin']).SetRange(2, 2)       # select prompt   
+            sparse.GetAxis(axes['Origin']).SetRange(2, 2)       # select prompt
         elif sparse_cfg['name'] == "RecoReflFD":
             sparse.GetAxis(axes['CandType']).SetRange(3, 4)     # select reflection
             sparse.GetAxis(axes['Origin']).SetRange(3, 3)       # select FD

--- a/utils/data_model.py
+++ b/utils/data_model.py
@@ -134,6 +134,7 @@ def get_sparse_dict(sparse_name, dmeson):
     else:
         if dmeson == 'Dzero':
             if sparse_name == "RecoPrompt" or sparse_name == "RecoFD" or sparse_name == "RecoRefl" or sparse_name == "RecoReflPrompt" or sparse_name == "RecoReflFD":
+                logger(f"Please confirming the axis for ScorePrompt and ScoreFD for D0 mc sparses", level='WARNING')
                 return {
                     'ScoreBkg': 0,
                     'ScorePrompt': 1,

--- a/utils/data_model.py
+++ b/utils/data_model.py
@@ -134,7 +134,6 @@ def get_sparse_dict(sparse_name, dmeson):
     else:
         if dmeson == 'Dzero':
             if sparse_name == "RecoPrompt" or sparse_name == "RecoFD" or sparse_name == "RecoRefl" or sparse_name == "RecoReflPrompt" or sparse_name == "RecoReflFD":
-                logger(f"Please confirming the axis for ScorePrompt and ScoreFD for D0 mc sparses", level='WARNING')
                 return {
                     'ScoreBkg': 0,
                     'ScorePrompt': 1,

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -604,7 +604,7 @@ def suggest_skip_cuts(hRawYields, hEffPrompt, hEffFD, nPtBins):
             ]):
                 logger(f'Suggested to skip cut {iCut} for pt bin {iPt+1} due to zero or negative efficiency/raw yield', level='WARNING')
                 suggested_skipped_cuts.append(iCut)
-            elif iCut == 0 and rys[0] == rys[1]:
+            elif iCut == 0 and nCuts > 1 and rys[0] == rys[1]:
                 logger(f'Suggested to skip cut {iCut} for pt bin {iPt+1} ({rys[iCut]}) due to identical raw yield as next cut', level='WARNING')
                 suggested_skipped_cuts.append(iCut)
             # raw yield differs from previous cut by less than 0.01%

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -585,6 +585,40 @@ def get_centrality_bins(centrality):
         print(f"ERROR: cent class \'{centrality}\' is not supported! Exit")
     sys.exit()
 
+def suggest_skip_cuts(hRawYields, hEffPrompt, hEffFD, nPtBins):
+    """Suggest cuts to skip based on zero or negative efficiencies or raw yields"""
+    nCuts = len(hRawYields)
+    suggested_skipped_cuts_pts = []
+    for iPt in range(nPtBins):
+        rys = [hRawYields[iCut].GetBinContent(iPt+1) for iCut in range(nCuts)]
+        effPs = [hEffPrompt[iCut].GetBinContent(iPt+1) for iCut in range(nCuts)]
+        effFs = [hEffFD[iCut].GetBinContent(iPt+1) for iCut in range(nCuts)]
+        suggested_skipped_cuts = []
+
+        for iCut in range(nCuts):
+            # zero or negative efficiencies or raw yields
+            if any([
+                rys[iCut] <= 0,
+                effPs[iCut] <= 0,
+                effFs[iCut] <= 0,
+            ]):
+                logger(f'Suggested to skip cut {iCut} for pt bin {iPt+1} due to zero or negative efficiency/raw yield', level='WARNING')
+                suggested_skipped_cuts.append(iCut)
+            elif iCut == 0 and rys[0] == rys[1]:
+                logger(f'Suggested to skip cut {iCut} for pt bin {iPt+1} ({rys[iCut]}) due to identical raw yield as next cut', level='WARNING')
+                suggested_skipped_cuts.append(iCut)
+            # raw yield differs from previous cut by less than 0.1%
+            elif iCut == nCuts - 1 and abs(rys[iCut] - rys[iCut-1]) / abs(rys[iCut]) < 0.0001:
+                logger(f'Suggested to skip cut {iCut} for pt bin {iPt+1} ({rys[iCut]}) due to negligible change in raw yield', level='WARNING')
+                suggested_skipped_cuts.append(iCut)
+            elif iCut > 0 and iCut < nCuts - 1 and abs(rys[iCut] - rys[iCut-1]) / abs(rys[iCut]) < 0.0001 and abs(rys[iCut] - rys[iCut+1]) / abs(rys[iCut]) < 0.0001: 
+                logger(f'Suggested to skip cut {iCut} for pt bin {iPt+1} ({rys[iCut]}) due to negligible change in raw yield', level='WARNING')
+                suggested_skipped_cuts.append(iCut)
+        suggested_skipped_cuts_pts.append(suggested_skipped_cuts)
+    for iPt, cuts in enumerate(suggested_skipped_cuts_pts):
+        print(f'\t\t{cuts}, # suggested cuts to skip for pt {iPt+1}')
+    return suggested_skipped_cuts_pts
+
 def reweight_histo_1D(histo, weights, binned=False):
     for iBin in range(1, histo.GetNbinsX()+1):
         ptCent = histo.GetBinCenter(iBin)

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -597,11 +597,9 @@ def suggest_skip_cuts(hRawYields, hEffPrompt, hEffFD, nPtBins):
 
         for iCut in range(nCuts):
             # zero or negative efficiencies or raw yields
-            if any([
-                rys[iCut] <= 0,
-                effPs[iCut] <= 0,
-                effFs[iCut] <= 0,
-            ]):
+            if any([rys[iCut] < 0, effPs[iCut] < 0, effFs[iCut] < 0]):
+				logger(f'Cut {iCut} for pt bin {iPt+1} has negative value, prompt eff={effPs[iCut]}, FD eff={effFs[iCut]}, ry={rys[iCut]}', level='ERROR')
+			elif any ([rys[iCut] == 0, effPs[iCut] == 0, effFs[iCut] == 0]):
                 logger(f'Suggested to skip cut {iCut} for pt bin {iPt+1} due to zero or negative efficiency/raw yield', level='WARNING')
                 suggested_skipped_cuts.append(iCut)
             elif iCut == 0 and nCuts > 1 and rys[0] == rys[1]:

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -607,7 +607,7 @@ def suggest_skip_cuts(hRawYields, hEffPrompt, hEffFD, nPtBins):
             elif iCut == 0 and rys[0] == rys[1]:
                 logger(f'Suggested to skip cut {iCut} for pt bin {iPt+1} ({rys[iCut]}) due to identical raw yield as next cut', level='WARNING')
                 suggested_skipped_cuts.append(iCut)
-            # raw yield differs from previous cut by less than 0.1%
+            # raw yield differs from previous cut by less than 0.01%
             elif iCut == nCuts - 1 and abs(rys[iCut] - rys[iCut-1]) / abs(rys[iCut]) < 0.0001:
                 logger(f'Suggested to skip cut {iCut} for pt bin {iPt+1} ({rys[iCut]}) due to negligible change in raw yield', level='WARNING')
                 suggested_skipped_cuts.append(iCut)


### PR DESCRIPTION
Dear @stefanopolitano, @zhangbiao-phy, and @Marcellocosti ,

I just updated the code a little bit for the D0 case to make it run smoothly.

- src/cut_variation.py
I added a `suggest_skip_cuts` function to automatically suggest and apply the cuts need to skip, detailed in `utils/utils.py`. At least for me, it's useful when scanning the full range for the correlated cutsets.

- src/get_vn_vs_mass.py
I may miss something somewhere. I didn't find this `libvnfitter.so`, if we just want to skip the recompilation, I would suggest using the `CompileMacro` with `kO`, then checking the `.so` file exists or not to decide skip the compilation or not. But I am not sure about the purpose, so I just commented out the line, and we can complete it next time.
**update** It will automatically load the shared library. https://root.cern/doc/master/classTSystem.html#ac557d8f24d067a9b89d2b8fb261d7e18

- src/pre_process.py
Fix some minor bugs for the D0 case.

At the end, I would suggest following the suggestion mentioned by Marcellocosti in the past, we should add some tests to make sure we are developing the code without breaking the code. But of course, it depends on the time.